### PR TITLE
Fix de l'événement : AFUP Poitiers — Soirée élections, AG Club418 et …

### DIFF
--- a/_events/2026-06-11.md
+++ b/_events/2026-06-11.md
@@ -1,11 +1,11 @@
 ---
 layout: event
-title: "AFUP Poitiers — Soirée échanges, élections et AG Club418"
+title: "AFUP Poitiers — Soirée élections, AG Club418 et échanges"
 date: 2026-06-11 19:00
 meetup_link: https://www.meetup.com/afup-poitiers-php/events/314996201/
 ---
 
-# AFUP Poitiers — Soirée échanges, élections et AG Club418
+# AFUP Poitiers — Soirée élections, AG Club418 et échanges
 
 L’antenne AFUP Poitiers et le Club418 vous donnent rendez-vous le jeudi 11 juin 2026 à partir de 19h au Tiers-lieu des Feuillants à Poitiers.
 Cette soirée prendra un format différent des meetups habituels : il n’y aura pas de conférence technique cette fois-ci, mais un moment d’échange autour de la communauté, de l’évolution de notre métier et des attentes pour l’année à venir.


### PR DESCRIPTION
…échanges